### PR TITLE
Default "$type" discriminator on JsonPolymorphicAttribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSwaggerGenOptionsExtensions.cs
@@ -91,7 +91,7 @@ public static class AnnotationsSwaggerGenOptionsExtensions
 
         if (jsonPolymorphicAttributes != null)
         {
-            return jsonPolymorphicAttributes.TypeDiscriminatorPropertyName;
+            return jsonPolymorphicAttributes.TypeDiscriminatorPropertyName ?? "$type";
         }
 
         return null;


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->
Default/null for the discriminator field is "$type" for  JsonPolymorphicAttribute (as van be seen in th [https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonpolymorphicattribute.typediscriminatorpropertyname?view=net-9.0#system-text-json-serialization-jsonpolymorphicattribute-typediscriminatorpropertyname](docs)). Without this fix the discriminator-mapping is not generated in the specification.